### PR TITLE
fix: Correct grammar and usage in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ python scripts/demo.py --video_path <your_frame_directory> --txt_path <path_to_f
 ## FAQs
 **Question 1:** Does SAMURAI need training? [issue 34](https://github.com/yangchris11/samurai/issues/34)
 
-**Answer 1:** Unlike real-life samurai, the proposed samurai do not require additional training. It is a zero-shot method, we directly use the weights from SAM 2.1 to conduct VOT experiments. Kalman filter is used to estimate the current and future state (bounding box location and scale in our case) of a moving object based on measurements over time, it is a common approach that had been adapt in the field of tracking for a long time which does not requires any training. Please refer to code for more detail.
+**Answer 1:** Unlike real-life samurai, the proposed samurai do not require additional training. It is a zero-shot method, we directly use the weights from SAM 2.1 to conduct VOT experiments. The Kalman filter is used to estimate the current and future state (bounding box location and scale in our case) of a moving object based on measurements over time, it is a common approach that had been adopted in the field of tracking for a long time, which does not require any training. Please refer to code for more detail.
 
 **Question 2:** Does SAMURAI support streaming input (e.g. webcam)?
 


### PR DESCRIPTION
- Corrected usage of "adopted" for proper word choice.
- Fixed grammar: "does not require" instead of "does not requires."
- Improved sentence clarity: "a long time, which does not require any training."
- Adjusted grammar for accuracy: "The Kalman filter is used."