### PR TITLE
Add Dockerfile and docker-compose setup for containerized usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM pytorch/pytorch:2.5.1-cuda12.1-cudnn9-devel
+
+# Prevent Python from buffering stdout/stderr
+ENV PYTHONUNBUFFERED=1
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install essential system packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    libavutil-dev \
+    libavcodec-dev \
+    libavformat-dev \
+    libswscale-dev \
+    pkg-config \
+    build-essential \
+    libffi-dev \
+    wget \
+    python3-opencv && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /workspace
+COPY . .
+
+# Install Python packages
+RUN pip install --upgrade pip setuptools && \
+    pip install -r requirements.txt && \
+    pip install hydra-core iopath decord
+
+# Download SAM2 model checkpoints
+RUN cd sam2/checkpoints && chmod +x download_ckpts.sh && ./download_ckpts.sh
+
+# Default command
+CMD ["/bin/bash"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,21 @@
+version: "3.9"
+
+services:
+  samurai:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: samurai_dev
+    runtime: nvidia  # Enable GPU access
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all  # Expose all GPUs
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
+    volumes:
+      - .:/workspace  # Mount project directory
+    working_dir: /workspace  # Set working directory inside container
+    stdin_open: true  # Keep STDIN open for interactive use
+    tty: true         # Allocate a pseudo-TTY
+    ipc: host         # Share IPC namespace (for performance)
+    ulimits:
+      memlock: -1      # Disable memory locking limits
+      stack: 67108864  # Increase stack size to 64MB


### PR DESCRIPTION
### Summary

This PR adds Docker support to the Samurai project:

- `Dockerfile`: Based on `pytorch/pytorch:2.5.1-cuda12.1-cudnn9-devel`
- `docker-compose.yaml`: Simplifies GPU-enabled container execution
- Verified to work on **Ubuntu 22.04 with NVIDIA GPU** (native Linux environment)

Thanks!

### Screenshots

### 📸 Screenshots

#### 🏗️ 1. Docker Build Started
Initial build process using `docker-compose build --no-cache`
Shows base image pull and package installation.
<img width="480" alt="1" src="https://github.com/user-attachments/assets/05d5e791-6378-4848-ad60-f02ff1cd8eb6" />


#### ✅ 2. Docker Build Completed
All checkpoints downloaded, build successfully finished and tagged.
<img width="480" alt="2" src="https://github.com/user-attachments/assets/4aa58a41-4068-4bc6-bc0c-f85229f0d320" />


#### 🚀 3. Container Running & Script Executed
Running `docker-compose run samurai` and executing `demo.py` inside container.
Shows successful inference in SAMURAI mode.
<img width="480" alt="3" src="https://github.com/user-attachments/assets/3892dc81-8f32-4a99-a531-772405b85364" />

### 📺 Demo Video

Here is a short demo showing the Docker container in action, running `demo.py` with test video:

▶️ [Watch on YouTube](https://www.youtube.com/watch?v=9vTPxeDtZoM)
